### PR TITLE
Fix_lock_cell_feature_not_work

### DIFF
--- a/package/rooter/ext-rooter-basic/files/usr/lib/lua/luci/view/rooter/lte_cell.htm
+++ b/package/rooter/ext-rooter-basic/files/usr/lib/lua/luci/view/rooter/lte_cell.htm
@@ -101,8 +101,8 @@
 		const id = `tr-${index}`;
 		const tr = document.getElementById(id);
 		const rowData = tr.querySelectorAll("td");
-		const PCID = rowData[8].innerHTML;
-		const EARFCN = rowData[9].innerHTML;
+		const PCID = rowData[8].innerHTML.replace(/\s/g, '');
+		const EARFCN = rowData[9].innerHTML.replace(/\s/g, '');
 		console.log(PCID, EARFCN)
 
 		// Request lock cell to back-end


### PR DESCRIPTION
Root cause:
- The redundant space in PCID and EARFCN string after parsing cause the issue